### PR TITLE
Build DJ Request MVP: auth, events, guest flow, QR, tipping, and SQLite backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env.local
+*.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# DJ Request (MVP)
+
+DJ Request is a full-stack web app for live song requests at bars, clubs, and private events.
+
+## Stack
+- **Frontend:** Next.js (React) with mobile-first UI
+- **Backend:** Next.js API routes (Node.js runtime)
+- **Database:** SQLite (`better-sqlite3`)
+- **Auth:** Email/password + signed HTTP-only JWT cookie sessions
+- **Realtime updates:** DJ dashboard polling every 3 seconds
+- **Payments:** Square Checkout flow (sandbox or production via env vars)
+
+## Features
+- DJ authentication (register/login/logout)
+- Event creation and lifecycle (live/ended)
+- Unique guest URL per event + QR code generation/download
+- Guest request form (no login)
+- Spam prevention via rate limiting per IP/event
+- DJ dashboard actions: accept, decline, mark played
+- Sort requests by tip amount or newest
+- Tip-aware UI highlighting + status handling
+- Square checkout initiation before request submission (when tip > 0)
+
+## Database schema
+Tables are auto-created on startup in `dj-request.db`:
+- `users(id, email, password_hash, created_at)`
+- `events(id, dj_id, name, description, slug, status, created_at, ended_at)`
+- `requests(id, event_id, song_name, artist, guest_message, status, tip_amount, payment_status, created_at, played_at)`
+
+## API endpoints
+### Auth
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `POST /api/auth/logout`
+- `GET /api/auth/me`
+
+### Events
+- `GET /api/events` (DJ only)
+- `POST /api/events` (DJ only)
+- `GET /api/events/:idOrSlug` (public)
+- `PATCH /api/events/:id` (DJ owner only)
+
+### Requests
+- `GET /api/requests?eventId=<id>&sort=time|tip` (DJ only)
+- `POST /api/requests` (guest submit)
+- `PATCH /api/requests/:id` (DJ owner only)
+
+### Payments
+- `POST /api/payments/create-checkout`
+
+## Square integration flow (example)
+1. Guest enters a tip amount in the request form.
+2. Frontend calls `POST /api/payments/create-checkout`.
+3. Backend uses Square `payment-links` API (sandbox/prod based on env).
+4. Guest is redirected to Square checkout URL in a new tab.
+5. Request is submitted with `paymentStatus=pending`.
+6. (Recommended next step): implement Square webhook endpoint to confirm settlement and update `requests.payment_status='paid'`.
+
+If Square credentials are absent, the app uses a mock payment response so local development still works.
+
+## Local setup
+1. Install deps
+   ```bash
+   npm install
+   ```
+2. Create `.env.local`
+   ```bash
+   JWT_SECRET=replace-with-a-long-random-string
+
+   # Optional Square
+   SQUARE_ENV=sandbox
+   SQUARE_APP_ID=
+   SQUARE_LOCATION_ID=
+   SQUARE_ACCESS_TOKEN=
+   ```
+3. Run dev server
+   ```bash
+   npm run dev
+   ```
+4. Open http://localhost:3000
+
+## Notes for bar-floor usability
+- Large, high-contrast action buttons for DJs
+- Mobile-friendly guest page
+- Minimal steps for quick request submission
+- Low-latency updates via frequent polling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1300 @@
+{
+  "name": "dj-request-system",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dj-request-system",
+      "version": "0.1.0",
+      "dependencies": {
+        "bcryptjs": "^2.4.3",
+        "better-sqlite3": "^11.7.0",
+        "cookie": "^1.0.2",
+        "jsonwebtoken": "^9.0.2",
+        "next": "14.1.0",
+        "qrcode": "^1.5.4",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.0.tgz",
+      "integrity": "sha512-Py8zIo+02ht82brwwhTg36iogzFqGLPXlRGKQw5s+qP/kMNc4MAyDeEwBKDijk6zTIbegEgu8Qy7C1LboslQAw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz",
+      "integrity": "sha512-nUDn7TOGcIeyQni6lZHfzNoo9S0euXnu0jhsbMOmMJUBfgsnESdjN97kM7cBqQxZa8L/bM9om/S5/1dzCrW6wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.0.tgz",
+      "integrity": "sha512-1jgudN5haWxiAl3O1ljUS2GfupPmcftu2RYJqZiMJmmbBT5M1XDffjUtRUzP4W3cBHsrvkfOFdQ71hAreNQP6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.0.tgz",
+      "integrity": "sha512-RHo7Tcj+jllXUbK7xk2NyIDod3YcCPDZxj1WLIYxd709BQ7WuRYl3OWUNG+WUfqeQBds6kvZYlc42NJJTNi4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.0.tgz",
+      "integrity": "sha512-v6kP8sHYxjO8RwHmWMJSq7VZP2nYCkRVQ0qolh2l6xroe9QjbgV8siTbduED4u0hlk0+tjS6/Tuy4n5XCp+l6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.0.tgz",
+      "integrity": "sha512-zJ2pnoFYB1F4vmEVlb/eSe+VH679zT1VdXlZKX+pE66grOgjmKJHKacf82g/sWE4MQ4Rk2FMBCRnX+l6/TVYzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.0.tgz",
+      "integrity": "sha512-rbaIYFt2X9YZBSbH/CwGAjbBG2/MrACCVu2X0+kSykHzHnYH5FjHxwXLkcoJ10cX0aWCEynpu+rP76x0914atg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.0.tgz",
+      "integrity": "sha512-o1N5TsYc8f/HpGt39OUQpQ9AKIGApd3QLueu7hXk//2xq5Z9OxmV6sQfNp8C7qYmiOlHYODOGqNNa0e9jvchGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.0.tgz",
+      "integrity": "sha512-XXIuB1DBRCFwNO6EEzCTMHT5pauwaSj4SWs7CYnME57eaReAKBXCnkUE80p/pAZcewm7hs+vGvNqDPacEXHVkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.0.tgz",
+      "integrity": "sha512-9WEbVRRAqJ3YFVqEZIxUqkiO8l1nool1LmNxygr5HWF8AcSYsEpneUDhmjUVJEzO2A04+oPtZdombzzPPkTtgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001772",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001772.tgz",
+      "integrity": "sha512-mIwLZICj+ntVTw4BT2zfp+yu/AqV6GMKfJVJMx3MwPxs+uk/uj2GLl2dH8LQbjiLDX66amCga5nKFyDgRR43kg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.1.0.tgz",
+      "integrity": "sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.1.0",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.1.0",
+        "@next/swc-darwin-x64": "14.1.0",
+        "@next/swc-linux-arm64-gnu": "14.1.0",
+        "@next/swc-linux-arm64-musl": "14.1.0",
+        "@next/swc-linux-x64-gnu": "14.1.0",
+        "@next/swc-linux-x64-musl": "14.1.0",
+        "@next/swc-win32-arm64-msvc": "14.1.0",
+        "@next/swc-win32-ia32-msvc": "14.1.0",
+        "@next/swc-win32-x64-msvc": "14.1.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,25 +9,13 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@radix-ui/react-alert-dialog": "^1.0.5",
-    "@radix-ui/react-dialog": "^1.0.5",
-    "@radix-ui/react-label": "^2.0.2",
-    "@radix-ui/react-select": "^2.0.0",
-    "@radix-ui/react-slot": "^1.0.2",
-    "@radix-ui/react-tabs": "^1.0.4",
-    "@supabase/supabase-js": "^2.39.7",
-    "class-variance-authority": "^0.7.0",
-    "clsx": "^2.1.0",
-    "lucide-react": "^0.334.0",
+    "bcryptjs": "^2.4.3",
+    "better-sqlite3": "^11.7.0",
+    "cookie": "^1.0.2",
+    "jsonwebtoken": "^9.0.2",
     "next": "14.1.0",
+    "qrcode": "^1.5.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "tailwind-merge": "^2.2.1",
-    "tailwindcss-animate": "^1.0.7"
-  },
-  "devDependencies": {
-    "autoprefixer": "^10.4.17",
-    "postcss": "^8.4.35",
-    "tailwindcss": "^3.4.1"
+    "react-dom": "^18.2.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+  plugins: {},
+};

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -1,0 +1,55 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import { parse, serialize } from 'cookie';
+
+const COOKIE_NAME = 'dj_session';
+const SESSION_TTL = 60 * 60 * 24 * 7;
+
+function jwtSecret() {
+  return process.env.JWT_SECRET || 'dev-only-change-me';
+}
+
+export async function hashPassword(password) {
+  return bcrypt.hash(password, 12);
+}
+
+export async function verifyPassword(password, hash) {
+  return bcrypt.compare(password, hash);
+}
+
+export function createSessionCookie(user) {
+  const token = jwt.sign({ sub: user.id, email: user.email }, jwtSecret(), {
+    expiresIn: SESSION_TTL,
+  });
+
+  return serialize(COOKIE_NAME, token, {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: SESSION_TTL,
+  });
+}
+
+export function clearSessionCookie() {
+  return serialize(COOKIE_NAME, '', {
+    path: '/',
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 0,
+  });
+}
+
+export function getSessionUser(req) {
+  const cookies = parse(req.headers.cookie || '');
+  const token = cookies[COOKIE_NAME];
+  if (!token) return null;
+
+  try {
+    const payload = jwt.verify(token, jwtSecret());
+    return { id: Number(payload.sub), email: payload.email };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -1,0 +1,44 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+
+const dbPath = path.join(process.cwd(), 'dj-request.db');
+const db = new Database(dbPath);
+
+db.pragma('journal_mode = WAL');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dj_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    slug TEXT UNIQUE NOT NULL,
+    status TEXT NOT NULL DEFAULT 'live',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    ended_at TEXT,
+    FOREIGN KEY(dj_id) REFERENCES users(id)
+  );
+
+  CREATE TABLE IF NOT EXISTS requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id INTEGER NOT NULL,
+    song_name TEXT NOT NULL,
+    artist TEXT NOT NULL,
+    guest_message TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    tip_amount REAL DEFAULT 0,
+    payment_status TEXT DEFAULT 'none',
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    played_at TEXT,
+    FOREIGN KEY(event_id) REFERENCES events(id)
+  );
+`);
+
+export default db;

--- a/src/lib/rateLimit.js
+++ b/src/lib/rateLimit.js
@@ -1,0 +1,18 @@
+const bucket = new Map();
+
+export function allowRequest(key, limit = 5, windowMs = 60_000) {
+  const now = Date.now();
+  const entry = bucket.get(key);
+
+  if (!entry || now > entry.resetAt) {
+    bucket.set(key, { count: 1, resetAt: now + windowMs });
+    return true;
+  }
+
+  if (entry.count >= limit) {
+    return false;
+  }
+
+  entry.count += 1;
+  return true;
+}

--- a/src/lib/square.js
+++ b/src/lib/square.js
@@ -1,0 +1,62 @@
+export function getSquareConfig() {
+  return {
+    appId: process.env.SQUARE_APP_ID,
+    locationId: process.env.SQUARE_LOCATION_ID,
+    accessToken: process.env.SQUARE_ACCESS_TOKEN,
+    baseUrl: process.env.SQUARE_ENV === 'production' ? 'https://connect.squareup.com' : 'https://connect.squareupsandbox.com',
+  };
+}
+
+export async function createSquareCheckout({ amountCents, note }) {
+  const { accessToken, baseUrl, locationId } = getSquareConfig();
+
+  if (!accessToken || !locationId) {
+    return {
+      checkoutUrl: '',
+      paymentId: `mock_${Date.now()}`,
+      paymentStatus: 'pending',
+      provider: 'mock',
+    };
+  }
+
+  const response = await fetch(`${baseUrl}/v2/online-checkout/payment-links`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      idempotency_key: `${Date.now()}-${Math.random()}`,
+      order: {
+        location_id: locationId,
+        line_items: [
+          {
+            name: 'DJ Request Tip',
+            quantity: '1',
+            base_price_money: {
+              amount: amountCents,
+              currency: 'USD',
+            },
+            note,
+          },
+        ],
+      },
+      checkout_options: {
+        ask_for_shipping_address: false,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`Square request failed: ${err}`);
+  }
+
+  const data = await response.json();
+  return {
+    checkoutUrl: data.payment_link?.url,
+    paymentId: data.payment_link?.id,
+    paymentStatus: 'pending',
+    provider: 'square',
+  };
+}

--- a/src/pages/api/auth/login.js
+++ b/src/pages/api/auth/login.js
@@ -1,0 +1,16 @@
+import db from '@/lib/db';
+import { createSessionCookie, verifyPassword } from '@/lib/auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const { email, password } = req.body;
+  const user = db.prepare('SELECT * FROM users WHERE email = ?').get((email || '').toLowerCase());
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+
+  const ok = await verifyPassword(password || '', user.password_hash);
+  if (!ok) return res.status(401).json({ error: 'Invalid credentials' });
+
+  res.setHeader('Set-Cookie', createSessionCookie({ id: user.id, email: user.email }));
+  return res.status(200).json({ user: { id: user.id, email: user.email } });
+}

--- a/src/pages/api/auth/logout.js
+++ b/src/pages/api/auth/logout.js
@@ -1,0 +1,7 @@
+import { clearSessionCookie } from '@/lib/auth';
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+  res.setHeader('Set-Cookie', clearSessionCookie());
+  res.status(200).json({ ok: true });
+}

--- a/src/pages/api/auth/me.js
+++ b/src/pages/api/auth/me.js
@@ -1,0 +1,7 @@
+import { getSessionUser } from '@/lib/auth';
+
+export default function handler(req, res) {
+  const user = getSessionUser(req);
+  if (!user) return res.status(401).json({ user: null });
+  res.status(200).json({ user });
+}

--- a/src/pages/api/auth/register.js
+++ b/src/pages/api/auth/register.js
@@ -1,0 +1,23 @@
+import db from '@/lib/db';
+import { createSessionCookie, hashPassword } from '@/lib/auth';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const { email, password } = req.body;
+  if (!email || !password || password.length < 8) {
+    return res.status(400).json({ error: 'Valid email and 8+ char password required' });
+  }
+
+  const exists = db.prepare('SELECT id FROM users WHERE email = ?').get(email.toLowerCase());
+  if (exists) return res.status(409).json({ error: 'Email already registered' });
+
+  const passwordHash = await hashPassword(password);
+  const result = db
+    .prepare('INSERT INTO users (email, password_hash) VALUES (?, ?)')
+    .run(email.toLowerCase(), passwordHash);
+
+  const user = { id: result.lastInsertRowid, email: email.toLowerCase() };
+  res.setHeader('Set-Cookie', createSessionCookie(user));
+  return res.status(201).json({ user });
+}

--- a/src/pages/api/events/[id].js
+++ b/src/pages/api/events/[id].js
@@ -1,0 +1,30 @@
+import db from '@/lib/db';
+import { getSessionUser } from '@/lib/auth';
+
+export default function handler(req, res) {
+  const { id } = req.query;
+
+  if (req.method === 'GET') {
+    const event = db.prepare('SELECT * FROM events WHERE id = ? OR slug = ?').get(id, id);
+    if (!event) return res.status(404).json({ error: 'Event not found' });
+    return res.status(200).json({ event });
+  }
+
+  const user = getSessionUser(req);
+  if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+  const event = db.prepare('SELECT * FROM events WHERE id = ?').get(id);
+  if (!event || event.dj_id !== user.id) return res.status(404).json({ error: 'Event not found' });
+
+  if (req.method === 'PATCH') {
+    const { name, description, status } = req.body;
+    db.prepare(
+      'UPDATE events SET name = ?, description = ?, status = ?, ended_at = CASE WHEN ? = "ended" THEN CURRENT_TIMESTAMP ELSE ended_at END WHERE id = ?'
+    ).run(name || event.name, description ?? event.description, status || event.status, status || event.status, id);
+
+    const updated = db.prepare('SELECT * FROM events WHERE id = ?').get(id);
+    return res.status(200).json({ event: updated });
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/src/pages/api/events/index.js
+++ b/src/pages/api/events/index.js
@@ -1,0 +1,30 @@
+import db from '@/lib/db';
+import { getSessionUser } from '@/lib/auth';
+import crypto from 'crypto';
+
+export default function handler(req, res) {
+  const user = getSessionUser(req);
+  if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+  if (req.method === 'GET') {
+    const events = db
+      .prepare('SELECT * FROM events WHERE dj_id = ? ORDER BY created_at DESC')
+      .all(user.id);
+    return res.status(200).json({ events });
+  }
+
+  if (req.method === 'POST') {
+    const { name, description } = req.body;
+    if (!name) return res.status(400).json({ error: 'Event name is required' });
+
+    const slug = crypto.randomBytes(8).toString('hex');
+    const result = db
+      .prepare('INSERT INTO events (dj_id, name, description, slug) VALUES (?, ?, ?, ?)')
+      .run(user.id, name, description || '', slug);
+
+    const event = db.prepare('SELECT * FROM events WHERE id = ?').get(result.lastInsertRowid);
+    return res.status(201).json({ event });
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/src/pages/api/payments/create-checkout.js
+++ b/src/pages/api/payments/create-checkout.js
@@ -1,0 +1,22 @@
+import { createSquareCheckout } from '@/lib/square';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const { tipAmount, songName } = req.body;
+  const amountCents = Math.round(Number(tipAmount || 0) * 100);
+
+  if (!amountCents || amountCents < 100) {
+    return res.status(400).json({ error: 'Tip must be at least $1.00' });
+  }
+
+  try {
+    const checkout = await createSquareCheckout({
+      amountCents,
+      note: `Tip for request: ${songName || 'Song request'}`,
+    });
+    return res.status(200).json(checkout);
+  } catch (error) {
+    return res.status(500).json({ error: error.message });
+  }
+}

--- a/src/pages/api/requests/[id].js
+++ b/src/pages/api/requests/[id].js
@@ -1,0 +1,24 @@
+import db from '@/lib/db';
+import { getSessionUser } from '@/lib/auth';
+
+export default function handler(req, res) {
+  if (req.method !== 'PATCH') return res.status(405).json({ error: 'Method not allowed' });
+
+  const user = getSessionUser(req);
+  if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+  const { id } = req.query;
+  const { status } = req.body;
+  const request = db.prepare('SELECT * FROM requests WHERE id = ?').get(id);
+  if (!request) return res.status(404).json({ error: 'Request not found' });
+
+  const event = db.prepare('SELECT * FROM events WHERE id = ?').get(request.event_id);
+  if (!event || event.dj_id !== user.id) return res.status(403).json({ error: 'Forbidden' });
+
+  db.prepare(
+    'UPDATE requests SET status = ?, played_at = CASE WHEN ? = "played" THEN CURRENT_TIMESTAMP ELSE played_at END WHERE id = ?'
+  ).run(status, status, id);
+
+  const updated = db.prepare('SELECT * FROM requests WHERE id = ?').get(id);
+  return res.status(200).json({ request: updated });
+}

--- a/src/pages/api/requests/index.js
+++ b/src/pages/api/requests/index.js
@@ -1,0 +1,44 @@
+import db from '@/lib/db';
+import { allowRequest } from '@/lib/rateLimit';
+import { getSessionUser } from '@/lib/auth';
+
+export default function handler(req, res) {
+  if (req.method === 'GET') {
+    const user = getSessionUser(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const { eventId, sort = 'time' } = req.query;
+    const event = db.prepare('SELECT * FROM events WHERE id = ?').get(eventId);
+    if (!event || event.dj_id !== user.id) return res.status(404).json({ error: 'Event not found' });
+
+    const orderClause = sort === 'tip' ? 'tip_amount DESC, created_at DESC' : 'created_at DESC';
+    const requests = db
+      .prepare(`SELECT * FROM requests WHERE event_id = ? ORDER BY ${orderClause}`)
+      .all(eventId);
+
+    return res.status(200).json({ requests });
+  }
+
+  if (req.method === 'POST') {
+    const { eventSlug, songName, artist, guestMessage, tipAmount, paymentStatus = 'none' } = req.body;
+    const clientKey = `${req.headers['x-forwarded-for'] || req.socket.remoteAddress}:${eventSlug}`;
+    if (!allowRequest(clientKey)) {
+      return res.status(429).json({ error: 'Too many requests. Please wait a minute.' });
+    }
+
+    const event = db.prepare('SELECT * FROM events WHERE slug = ?').get(eventSlug);
+    if (!event || event.status !== 'live') return res.status(404).json({ error: 'Event unavailable' });
+
+    if (!songName || !artist) return res.status(400).json({ error: 'Song and artist required' });
+
+    const result = db.prepare(
+      `INSERT INTO requests (event_id, song_name, artist, guest_message, tip_amount, payment_status)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    ).run(event.id, songName, artist, guestMessage || '', Number(tipAmount || 0), paymentStatus);
+
+    const request = db.prepare('SELECT * FROM requests WHERE id = ?').get(result.lastInsertRowid);
+    return res.status(201).json({ request });
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' });
+}

--- a/src/pages/event/[id].js
+++ b/src/pages/event/[id].js
@@ -1,252 +1,102 @@
-import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { createClient } from '@supabase/supabase-js';
-import { Card, CardHeader, CardTitle, CardContent, CardDescription } from '@/components/ui/card';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
-import { ArrowLeft, DollarSign } from 'lucide-react';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Badge } from '@/components/ui/badge';
+import { useEffect, useState } from 'react';
 
-// Initialize Supabase client
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL || '',
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
-);
-
-const EventPage = () => {
+export default function GuestEventPage() {
   const router = useRouter();
   const { id } = router.query;
   const [event, setEvent] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
-  const [requests, setRequests] = useState([]);
-  const [newRequest, setNewRequest] = useState({
-    songName: '',
-    artist: '',
-    specialRequest: '',
-    tipAmount: 0
-  });
-  const [requestStatus, setRequestStatus] = useState('');
+  const [form, setForm] = useState({ songName: '', artist: '', guestMessage: '', tipAmount: '' });
+  const [message, setMessage] = useState('');
 
-  // Fetch event and requests when id is available
   useEffect(() => {
-    if (id) {
-      fetchEventDetails();
-    }
+    if (!id) return;
+    fetch(`/api/events/${id}`).then(async (res) => {
+      const data = await res.json();
+      if (res.ok) setEvent(data.event);
+      else setMessage(data.error || 'Event unavailable');
+    });
   }, [id]);
 
-  // Function to fetch event details
-  const fetchEventDetails = async () => {
-    try {
-      const { data: eventData, error: eventError } = await supabase
-        .from('events')
-        .select('*')
-        .eq('id', id)
-        .single();
+  async function createTipCheckout() {
+    const res = await fetch('/api/payments/create-checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tipAmount: form.tipAmount, songName: form.songName }),
+    });
 
-      if (eventError) throw eventError;
-
-      setEvent(eventData);
-
-      const { data: requestsData, error: requestsError } = await supabase
-        .from('requests')
-        .select('*')
-        .eq('event_id', id)
-        .order('created_at', { ascending: false });
-
-      if (requestsError) throw requestsError;
-
-      setRequests(requestsData || []);
-    } catch (err) {
-      console.error('Error:', err);
-      setError(err.message);
-    } finally {
-      setLoading(false);
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Payment start failed');
+    if (data.checkoutUrl) {
+      window.open(data.checkoutUrl, '_blank', 'noopener,noreferrer');
     }
-  };
-
-  const handleSubmitRequest = async (e) => {
-    e.preventDefault();
-    setRequestStatus('');
-
-    try {
-      const { data, error } = await supabase
-        .from('requests')
-        .insert([
-          {
-            event_id: id,
-            song_name: newRequest.songName,
-            artist: newRequest.artist,
-            special_request: newRequest.specialRequest,
-            tip_amount: parseFloat(newRequest.tipAmount) || 0,
-            status: 'pending'
-          }
-        ])
-        .select();
-
-      if (error) throw error;
-
-      setRequests([data[0], ...requests]);
-      setNewRequest({
-        songName: '',
-        artist: '',
-        specialRequest: '',
-        tipAmount: 0
-      });
-      setRequestStatus('Request submitted successfully!');
-      
-      await fetchEventDetails();
-    } catch (error) {
-      console.error('Error submitting request:', error);
-      setRequestStatus(`Error submitting request: ${error.message}`);
-    }
-  };
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 p-4">
-        <div className="max-w-4xl mx-auto text-center">
-          Loading event details...
-        </div>
-      </div>
-    );
+    return data.paymentStatus;
   }
 
-  if (error || !event) {
-    return (
-      <div className="min-h-screen bg-gray-50 p-4">
-        <div className="max-w-4xl mx-auto">
-          <Alert variant="destructive">
-            <AlertDescription>
-              {error || 'Event not found'}
-            </AlertDescription>
-          </Alert>
-          <Button
-            className="mt-4"
-            variant="outline"
-            onClick={() => router.push('/')}
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Events
-          </Button>
-        </div>
-      </div>
-    );
+  async function submitRequest(e) {
+    e.preventDefault();
+    setMessage('');
+
+    let paymentStatus = 'none';
+    try {
+      if (Number(form.tipAmount) > 0) {
+        paymentStatus = await createTipCheckout();
+      }
+
+      const res = await fetch('/api/requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventSlug: event.slug,
+          ...form,
+          paymentStatus,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Submit failed');
+      setMessage('Request sent! The DJ sees it in real time.');
+      setForm({ songName: '', artist: '', guestMessage: '', tipAmount: '' });
+    } catch (error) {
+      setMessage(error.message);
+    }
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <div className="max-w-4xl mx-auto">
-       
+    <main className="container mobile">
+      <h1>{event?.name || 'DJ Request'}</h1>
+      <p className="subtitle">{event?.status === 'ended' ? 'This event has ended.' : 'Submit your song request below.'}</p>
 
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle>{event.name}</CardTitle>
-            <CardDescription>
-              Event Date: {new Date(event.date).toLocaleDateString()} {new Date(event.date).toLocaleTimeString()}
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {event.description && (
-              <div className="mb-4">
-                <h3 className="font-semibold">Description</h3>
-                <p className="text-gray-600">{event.description}</p>
-              </div>
-            )}
-            
-            <div>
-              <h3 className="font-semibold">Event Details</h3>
-              <p className="text-gray-600">
-                Total Requests: {requests.length}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+      {event?.status === 'live' && (
+        <form className="panel stack" onSubmit={submitRequest}>
+          <input
+            placeholder="Song name"
+            value={form.songName}
+            onChange={(e) => setForm({ ...form, songName: e.target.value })}
+            required
+          />
+          <input
+            placeholder="Artist"
+            value={form.artist}
+            onChange={(e) => setForm({ ...form, artist: e.target.value })}
+            required
+          />
+          <textarea
+            placeholder="Message for DJ (optional)"
+            value={form.guestMessage}
+            onChange={(e) => setForm({ ...form, guestMessage: e.target.value })}
+          />
+          <input
+            type="number"
+            min="0"
+            step="1"
+            placeholder="Tip amount in USD (optional)"
+            value={form.tipAmount}
+            onChange={(e) => setForm({ ...form, tipAmount: e.target.value })}
+          />
+          <button type="submit" className="btn-primary big">Send Request</button>
+        </form>
+      )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Make a Song Request</CardTitle>
-            <CardDescription>
-              Submit your song request for this event
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {requestStatus && (
-              <Alert className="mb-4">
-                <AlertDescription>{requestStatus}</AlertDescription>
-              </Alert>
-            )}
-            
-            <form onSubmit={handleSubmitRequest} className="space-y-6">
-              <div className="space-y-2">
-                <Label htmlFor="songName">Song Name</Label>
-                <Input
-                  id="songName"
-                  placeholder="Enter the song name"
-                  value={newRequest.songName}
-                  onChange={(e) => setNewRequest({...newRequest, songName: e.target.value})}
-                  required
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="artist">Artist</Label>
-                <Input
-                  id="artist"
-                  placeholder="Enter the artist name"
-                  value={newRequest.artist}
-                  onChange={(e) => setNewRequest({...newRequest, artist: e.target.value})}
-                  required
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="specialRequest">Special Request (Optional)</Label>
-                <Textarea
-                  id="specialRequest"
-                  placeholder="Add any special notes or dedications..."
-                  value={newRequest.specialRequest}
-                  onChange={(e) => setNewRequest({...newRequest, specialRequest: e.target.value})}
-                  className="min-h-[100px]"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="tipAmount">Tip Amount (Optional)</Label>
-                <div className="relative">
-                  <div className="absolute left-3 top-1/2 -translate-y-1/2">
-                    <Badge variant="secondary" className="bg-gray-100 hover:bg-gray-100">
-                      <DollarSign className="h-4 w-4 text-gray-500" />
-                    </Badge>
-                  </div>
-                  <Input
-                    id="tipAmount"
-                    type="number"
-                    min="0"
-                    step="1"
-                    placeholder="0"
-                    value={newRequest.tipAmount}
-                    onChange={(e) => setNewRequest({...newRequest, tipAmount: e.target.value})}
-                    className="pl-12"
-                  />
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  Add an optional tip to increase your request priority
-                </p>
-              </div>
-
-              <Button type="submit" className="w-full">
-                Submit Request
-              </Button>
-            </form>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+      {message && <p className="info">{message}</p>}
+    </main>
   );
-};
-
-export default EventPage;
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,574 +1,260 @@
-import React, { useState, useEffect } from 'react';
-import { createClient } from '@supabase/supabase-js';
-import { useRouter } from 'next/router';
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Label } from '@/components/ui/label';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import {
-  Music,
-  LockKeyhole,
-  PlayCircle,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  DollarSign,
-  Users,
-  LogOut
-} from 'lucide-react';
-import EventCreationForm from '@/components/EventCreationForm';
+import { useEffect, useMemo, useState } from 'react';
+import QRCode from 'qrcode';
 
-// Initialize Supabase client
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-);
+const emptyEvent = { name: '', description: '' };
 
 export default function Home() {
-  const router = useRouter();
-  const [isRegistering, setIsRegistering] = useState(false);
-  const [registerData, setRegisterData] = useState({
-    email: '',
-    password: '',
-    confirmPassword: ''
-  });
-  const [isDjView, setIsDjView] = useState(false);
-  const [eventLoading, setEventLoading] = useState(false);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const [authMode, setAuthMode] = useState('login');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [message, setMessage] = useState('');
+  const [user, setUser] = useState(null);
   const [events, setEvents] = useState([]);
-  const [activeEvent, setActiveEvent] = useState(null);
+  const [selectedEventId, setSelectedEventId] = useState(null);
   const [requests, setRequests] = useState([]);
+  const [eventForm, setEventForm] = useState(emptyEvent);
+  const [sortBy, setSortBy] = useState('time');
+  const [message, setMessage] = useState('');
+  const [origin, setOrigin] = useState('');
+
+  const selectedEvent = useMemo(
+    () => events.find((event) => event.id === selectedEventId),
+    [events, selectedEventId]
+  );
 
   useEffect(() => {
-    checkUser();
-    fetchEvents();
+    setOrigin(window.location.origin);
+    fetch('/api/auth/me').then(async (res) => {
+      const data = await res.json();
+      if (data.user) {
+        setUser(data.user);
+      }
+    });
   }, []);
 
   useEffect(() => {
-    if (activeEvent) {
-      fetchRequests(activeEvent.id);
+    if (user) {
+      loadEvents();
     }
-  }, [activeEvent]);
+  }, [user]);
 
-  async function checkUser() {
-    try {
-      const { data: { session }, error } = await supabase.auth.getSession();
-      setUser(session?.user ?? null);
-      setIsLoggedIn(!!session?.user);
-    } catch (error) {
-      console.error('Error checking user:', error.message);
-    } finally {
-      setLoading(false);
-    }
-  }
+  useEffect(() => {
+    if (!selectedEventId || !user) return;
 
-  async function fetchEvents() {
-    try {
-      let query = supabase.from('events').select('*').order('date', { ascending: true });
-      
-      // If in DJ view and logged in, only fetch their events
-      if (isDjView && user) {
-        query = query.eq('dj_id', user.id);
-      }
-      
-      const { data, error } = await query;
-      
-      if (error) throw error;
-      setEvents(data || []);
-      if (data?.length > 0 && !activeEvent) {
-        setActiveEvent(data[0]);
-      }
-    } catch (error) {
-      console.error('Error fetching events:', error.message);
-      setMessage('Error loading events');
+    loadRequests(selectedEventId, sortBy);
+    const timer = setInterval(() => loadRequests(selectedEventId, sortBy), 3000);
+    return () => clearInterval(timer);
+  }, [selectedEventId, user, sortBy]);
+
+  async function loadEvents() {
+    const res = await fetch('/api/events');
+    const data = await res.json();
+    setEvents(data.events || []);
+    if (!selectedEventId && data.events?.length) {
+      setSelectedEventId(data.events[0].id);
     }
   }
 
-  async function fetchRequests(eventId) {
-    try {
-      const { data, error } = await supabase
-        .from('requests')
-        .select('*')
-        .eq('event_id', eventId)
-        .order('created_at', { ascending: false });
-      
-      if (error) throw error;
-      setRequests(data || []);
-    } catch (error) {
-      console.error('Error fetching requests:', error.message);
-      setMessage('Error loading requests');
+  async function loadRequests(eventId, sort = 'time') {
+    const res = await fetch(`/api/requests?eventId=${eventId}&sort=${sort}`);
+    const data = await res.json();
+    if (res.ok) {
+      setRequests(data.requests);
     }
   }
 
-  const handleRegister = async (e) => {
+  async function submitAuth(e) {
     e.preventDefault();
-    
-    if (registerData.password !== registerData.confirmPassword) {
-      setMessage('Passwords do not match');
+    setMessage('');
+
+    const endpoint = authMode === 'register' ? '/api/auth/register' : '/api/auth/login';
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+
+    const data = await res.json();
+    if (!res.ok) {
+      setMessage(data.error || 'Authentication failed');
       return;
     }
 
-    try {
-      const { data, error } = await supabase.auth.signUp({
-        email: registerData.email,
-        password: registerData.password
-      });
+    setUser(data.user);
+    setEmail('');
+    setPassword('');
+  }
 
-      if (error) throw error;
+  async function logout() {
+    await fetch('/api/auth/logout', { method: 'POST' });
+    setUser(null);
+    setEvents([]);
+    setRequests([]);
+  }
 
-      setMessage('Registration successful! Please check your email for verification.');
-      setIsRegistering(false);
-    } catch (error) {
-      setMessage(error.message);
-    }
-  };
-
-  async function handleDjLogin(e) {
+  async function createEvent(e) {
     e.preventDefault();
-    try {
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
+    const res = await fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(eventForm),
+    });
+    const data = await res.json();
+    if (!res.ok) return setMessage(data.error || 'Could not create event');
+    setEventForm(emptyEvent);
+    setEvents([data.event, ...events]);
+    setSelectedEventId(data.event.id);
+  }
 
-      if (error) throw error;
-      setUser(data.user);
-      setIsLoggedIn(true);
-      setMessage('Successfully logged in!');
-      fetchEvents();
-    } catch (error) {
-      console.error('Error logging in:', error.message);
-      setMessage(error.message);
+  async function updateEvent(status) {
+    if (!selectedEvent) return;
+    const res = await fetch(`/api/events/${selectedEvent.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setEvents(events.map((event) => (event.id === data.event.id ? data.event : event)));
     }
   }
 
-  async function handleLogout() {
-    try {
-      const { error } = await supabase.auth.signOut();
-      if (error) throw error;
-      setUser(null);
-      setIsLoggedIn(false);
-      setMessage('Logged out successfully');
-      fetchEvents();
-    } catch (error) {
-      console.error('Error logging out:', error.message);
-      setMessage('Error logging out');
-    }
+  async function updateRequest(id, status) {
+    await fetch(`/api/requests/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    loadRequests(selectedEventId, sortBy);
   }
 
-  async function handleEventSubmit(formData) {
-    setEventLoading(true);
-    setMessage('');
-
-    try {
-      if (!user) {
-        throw new Error('You must be logged in to create events');
-      }
-
-      const { data, error } = await supabase
-        .from('events')
-        .insert([
-          {
-            name: formData.name,
-            date: new Date(formData.date).toISOString(),
-            description: formData.description || '',
-            dj_id: user.id
-          }
-        ])
-        .select();
-
-      if (error) throw error;
-
-      if (data) {
-        setEvents(prevEvents => [...prevEvents, data[0]]);
-        setMessage('Event created successfully!');
-        router.push(`/event/${data[0].id}`);
-      }
-    } catch (error) {
-      console.error('Error:', error);
-      setMessage(error.message || 'Error creating event');
-    } finally {
-      setEventLoading(false);
-    }
+  if (!user) {
+    return (
+      <main className="container">
+        <h1>DJ Request</h1>
+        <p className="subtitle">Fast request management for bars, clubs, and private events.</p>
+        <form onSubmit={submitAuth} className="panel stack">
+          <h2>{authMode === 'register' ? 'Create DJ account' : 'DJ login'}</h2>
+          <input placeholder="Email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+          <input
+            placeholder="Password (min 8 characters)"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <button type="submit" className="btn-primary">{authMode === 'register' ? 'Create account' : 'Login'}</button>
+          <button type="button" className="btn-ghost" onClick={() => setAuthMode(authMode === 'register' ? 'login' : 'register')}>
+            {authMode === 'register' ? 'Already have an account?' : 'Need an account?'}
+          </button>
+          {message && <p className="error">{message}</p>}
+        </form>
+      </main>
+    );
   }
 
-  async function updateRequestStatus(id, status) {
-    try {
-      const { data, error } = await supabase
-        .from('requests')
-        .update({ status })
-        .eq('id', id)
-        .select();
-
-      if (error) throw error;
-      setRequests(requests.map(request => 
-        request.id === id ? { ...request, status } : request
-      ));
-    } catch (error) {
-      console.error('Error updating request:', error.message);
-      setMessage('Error updating request status');
-    }
-  }
-
-  const stats = {
-    totalRequests: requests.length,
-    completedRequests: requests.filter(r => r.status === 'completed').length,
-    pendingRequests: requests.filter(r => r.status === 'pending').length,
-    totalTips: requests.reduce((sum, r) => sum + (parseFloat(r.tip_amount) || 0), 0)
-  };
-
-const DjDashboard = () => (
-  <div className="space-y-6">
-  {/* Add Logout Button */}
-   <div className="flex justify-end">
-      <Button 
-        onClick={handleLogout}
-        variant="outline"
-        className="flex items-center gap-2"
-      >
-        <LogOut className="h-4 w-4" />
-        Logout
-      </Button>
-    </div>
-    <EventCreationForm onSubmit={handleEventSubmit} isLoading={eventLoading} />
-
-    {/* Statistics Cards */}
-    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-      {[
-        { label: "Total Requests", value: stats.totalRequests, icon: Users },
-        { label: "Pending", value: stats.pendingRequests, icon: Clock },
-        { label: "Completed", value: stats.completedRequests, icon: CheckCircle2 },
-        { label: "Total Tips", value: `$${stats.totalTips.toFixed(2)}`, icon: DollarSign }
-      ].map((stat, i) => (
-        <Card key={i}>
-          <CardContent className="p-4 flex items-center justify-between">
-            <div>
-              <p className="text-sm text-gray-500">{stat.label}</p>
-              <p className="text-2xl font-bold">{stat.value}</p>
-            </div>
-            <stat.icon className="h-8 w-8 text-gray-400" />
-          </CardContent>
-        </Card>
-      ))}
-    </div>
-
-    {/* Request Management */}
-    {activeEvent && (
-      <Card id="requestManagement">
-        <CardHeader>
-          <CardTitle>Request Management - {activeEvent.name}</CardTitle>
-          <CardDescription>Manage song requests for this event</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Tabs defaultValue="pending" className="w-full">
-            <TabsList>
-              <TabsTrigger value="pending">Pending</TabsTrigger>
-              <TabsTrigger value="playing">Now Playing</TabsTrigger>
-              <TabsTrigger value="completed">Completed</TabsTrigger>
-              <TabsTrigger value="rejected">Rejected</TabsTrigger>
-            </TabsList>
-
-            {['pending', 'playing', 'completed', 'rejected'].map(status => (
-              <TabsContent key={status} value={status}>
-                <div className="space-y-4">
-                  {requests.filter(r => r.status === status).map((request) => (
-                    <Card key={request.id}>
-                      <CardContent className="p-4">
-                        <div className="flex justify-between items-start">
-                          <div className="space-y-1">
-                            <h4 className="font-semibold">{request.song_name}</h4>
-                            <p className="text-sm text-gray-600">{request.artist}</p>
-                            {request.special_request && (
-                              <p className="text-sm text-gray-500">Note: {request.special_request}</p>
-                            )}
-                            {request.tip_amount > 0 && (
-                              <Badge variant="secondary">
-                                <DollarSign className="h-3 w-3 mr-1" />
-                                Tip: ${parseFloat(request.tip_amount).toFixed(2)}
-                              </Badge>
-                            )}
-                          </div>
-                          <div className="flex gap-2">
-                            {status === 'pending' && (
-                              <>
-                                <Button
-                                  size="sm"
-                                  onClick={() => updateRequestStatus(request.id, 'playing')}
-                                  className="bg-green-600 hover:bg-green-700"
-                                >
-                                  <PlayCircle className="h-4 w-4 mr-1" />
-                                  Play
-                                </Button>
-                                <Button
-                                  size="sm"
-                                  variant="destructive"
-                                  onClick={() => updateRequestStatus(request.id, 'rejected')}
-                                >
-                                  <XCircle className="h-4 w-4 mr-1" />
-                                  Reject
-                                </Button>
-                              </>
-                            )}
-                            {status === 'playing' && (
-                              <Button
-                                size="sm"
-                                onClick={() => updateRequestStatus(request.id, 'completed')}
-                                className="bg-blue-600 hover:bg-blue-700"
-                              >
-                                <CheckCircle2 className="h-4 w-4 mr-1" />
-                                Complete
-                              </Button>
-                            )}
-                          </div>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  ))}
-                  {requests.filter(r => r.status === status).length === 0 && (
-                    <p className="text-center text-gray-500 py-4">No {status} requests</p>
-                  )}
-                </div>
-              </TabsContent>
-            ))}
-          </Tabs>
-        </CardContent>
-      </Card>
-    )}
-
-    {/* Events List - Now below Request Management */}
-    <Card className="mt-6">
-      <CardHeader>
-        <CardTitle>Your Events</CardTitle>
-        <CardDescription>Select an event to manage requests</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          <select
-            className="w-full px-4 py-2 bg-white border border-gray-300 rounded-md cursor-pointer hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            onChange={(e) => {
-              if (e.target.value) {
-                const selectedEvent = events.find(event => event.id.toString() === e.target.value);
-                setActiveEvent(selectedEvent);
-              }
-            }}
-            value={activeEvent?.id || "default"}
-          >
-            <option value="default" disabled>Select an Event</option>
-            {events.map((event) => (
-              <option key={event.id} value={event.id}>
-                {event.name} - {new Date(event.date).toLocaleDateString()}
-              </option>
-            ))}
-          </select>
-
-          {activeEvent && (
-            <Card className="p-4">
-              <div className="flex justify-between items-center">
-                <div>
-                  <h3 className="font-semibold">{activeEvent.name}</h3>
-                  <p className="text-sm text-gray-500">
-                    {new Date(activeEvent.date).toLocaleDateString()}
-                  </p>
-                </div>
-                <div className="flex gap-2">
-                  <Button 
-                    variant="outline"
-                    onClick={() => router.push(`/event/${activeEvent.id}`)}
-                  >
-                    View Event Page
-                  </Button>
-                </div>
-              </div>
-            </Card>
-          )}
-        </div>
-      </CardContent>
-    </Card>
-  </div>
-);
   return (
-    <div className="min-h-screen bg-gray-50 p-4">
-      <div className="max-w-6xl mx-auto">
-        {/* Header */}
-        <div className="flex justify-between items-center mb-6">
-          <h1 className="text-2xl font-bold text-gray-900">DJ Event Management System</h1>
-          <Button 
-            onClick={() => setIsDjView(!isDjView)}
-            variant="outline"
-            className="flex items-center gap-2"
-          >
-            {isDjView ? <Music className="h-4 w-4" /> : <LockKeyhole className="h-4 w-4" />}
-            Switch to {isDjView ? 'Request' : 'DJ'} View
-          </Button>
+    <main className="container">
+      <div className="row spread">
+        <h1>DJ Dashboard</h1>
+        <button className="btn-ghost" onClick={logout}>Logout</button>
+      </div>
+
+      <section className="panel stack">
+        <h2>Create event</h2>
+        <form className="stack" onSubmit={createEvent}>
+          <input
+            placeholder="Event name"
+            value={eventForm.name}
+            onChange={(e) => setEventForm({ ...eventForm, name: e.target.value })}
+            required
+          />
+          <textarea
+            placeholder="Description (optional)"
+            value={eventForm.description}
+            onChange={(e) => setEventForm({ ...eventForm, description: e.target.value })}
+          />
+          <button className="btn-primary" type="submit">Create live event</button>
+        </form>
+      </section>
+
+      <section className="panel stack">
+        <h2>Your events</h2>
+        <div className="grid">
+          {events.map((event) => (
+            <button
+              key={event.id}
+              onClick={() => setSelectedEventId(event.id)}
+              className={`event-card ${selectedEventId === event.id ? 'selected' : ''}`}
+            >
+              <div className="row spread"><strong>{event.name}</strong><span>{event.status}</span></div>
+              <small>{origin ? `${origin}/event/${event.slug}` : `/event/${event.slug}`}</small>
+            </button>
+          ))}
         </div>
+      </section>
 
-        {/* Messages */}
-        {message && (
-          <Alert className="mb-4">
-            <AlertDescription>{message}</AlertDescription>
-          </Alert>
-        )}
+      {selectedEvent && (
+        <section className="panel stack">
+          <div className="row spread">
+            <h2>{selectedEvent.name}</h2>
+            <div className="row">
+              <button className="btn-warn" onClick={() => updateEvent('ended')}>End Event</button>
+              <button className="btn-ghost" onClick={() => updateEvent('live')}>Go Live</button>
+            </div>
+          </div>
 
-        {/* Main Content */}
-        {isDjView ? (
-          <Card className="border-t-4 border-t-blue-600">
-            <CardHeader>
-              <CardTitle>DJ Dashboard</CardTitle>
-              <CardDescription>Manage song requests and event details</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {!isLoggedIn ? (
-                <div className="space-y-4 max-w-md mx-auto">
-                  {!isRegistering ? (
-                    <>
-                      <form onSubmit={handleDjLogin} className="space-y-4">
-                        <div>
-                          <Label htmlFor="email">Email</Label>
-                          <Input
-                            id="email"
-                            type="email"
-                            value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                            placeholder="Enter your email"
-                            required
-                          />
-                        </div>
-                        <div>
-                          <Label htmlFor="password">Password</Label>
-                          <Input
-                            id="password"
-                            type="password"
-                            value={password}
-                            onChange={(e) => setPassword(e.target.value)}
-                            placeholder="Enter your password"
-                            required
-                          />
-                        </div>
-                        <Button type="submit" className="w-full">Login</Button>
-                      </form>
-                      
-                      <div className="relative my-6">
-                        <div className="absolute inset-0 flex items-center">
-                          <span className="w-full border-t" />
-                        </div>
-                        <div className="relative flex justify-center text-xs uppercase">
-                          <span className="bg-background px-2 text-muted-foreground">
-                            Or
-                          </span>
-                        </div>
-                      </div>
+          <EventQr slug={selectedEvent.slug} origin={origin} />
 
-                      <Button 
-                        type="button" 
-                        variant="outline" 
-                        className="w-full"
-                        onClick={() => setIsRegistering(true)}
-                      >
-                        Create New DJ Account
-                      </Button>
-                    </>
-                  ) : (
-                    <form onSubmit={handleRegister} className="space-y-4">
-                      <div>
-                        <Label htmlFor="registerEmail">Email</Label>
-                        <Input
-                          id="registerEmail"
-                          type="email"
-                          value={registerData.email}
-                          onChange={(e) => setRegisterData({ ...registerData, email: e.target.value })}
-                          placeholder="Enter your email"
-                          required
-                        />
-                      </div>
-                      <div>
-                        <Label htmlFor="registerPassword">Password</Label>
-                        <Input
-                          id="registerPassword"
-                          type="password"
-                          value={registerData.password}
-                          onChange={(e) => setRegisterData({ ...registerData, password: e.target.value })}
-                          placeholder="Create a password"
-                          required
-                          minLength={6}
-                        />
-                      </div>
-                      <div>
-                        <Label htmlFor="confirmPassword">Confirm Password</Label>
-                        <Input
-                          id="confirmPassword"
-                          type="password"
-                          value={registerData.confirmPassword}
-                          onChange={(e) => setRegisterData({ ...registerData, confirmPassword: e.target.value })}
-                          placeholder="Confirm your password"
-                          required
-                        />
-                      </div>
-                      <Button type="submit" className="w-full">Register</Button>
-                      <Button 
-                        type="button" 
-                        variant="outline" 
-                        className="w-full"
-                        onClick={() => setIsRegistering(false)}
-                      >
-                        Back to Login
-                      </Button>
-                    </form>
-                  )}
+          <div className="row spread">
+            <h3>Incoming requests</h3>
+            <select value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+              <option value="time">Sort by time</option>
+              <option value="tip">Sort by tip</option>
+            </select>
+          </div>
+
+          <div className="stack">
+            {requests.map((request) => (
+              <article key={request.id} className={`request ${request.tip_amount > 0 ? 'tipped' : ''}`}>
+                <div className="row spread">
+                  <strong>{request.song_name} — {request.artist}</strong>
+                  <span>{request.tip_amount > 0 ? `$${request.tip_amount}` : 'No tip'}</span>
                 </div>
-              ) : (
-                <DjDashboard />
-              )}
-            </CardContent>
-          </Card>
-        ) : (
-          // Public View - List of Events
-          <Card className="border-t-4 border-t-purple-600">
-            <CardHeader>
-              <CardTitle>Upcoming Events</CardTitle>
-              <CardDescription>Select an event to make a song request</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-4">
-                {events.length > 0 ? (
-                  events.map((event) => (
-                    <Card key={event.id} className="p-4">
-                      <div className="flex justify-between items-center">
-                        <div>
-                          <h3 className="font-semibold">{event.name}</h3>
-                          <p className="text-sm text-gray-500">
-                            {new Date(event.date).toLocaleDateString()}
-                          </p>
-                          {event.description && (
-                            <p className="text-sm text-gray-600 mt-1">{event.description}</p>
-                          )}
-                        </div>
-                        <Button 
-                          onClick={() => router.push(`/event/${event.id}`)}
-                        >
-                          Make Request
-                        </Button>
-                      </div>
-                    </Card>
-                  ))
-                ) : (
-                  <p className="text-center text-gray-500">No upcoming events</p>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        )}
+                {request.guest_message && <p>{request.guest_message}</p>}
+                <div className="row">
+                  <button className="btn-primary" onClick={() => updateRequest(request.id, 'accepted')}>Accept</button>
+                  <button className="btn-warn" onClick={() => updateRequest(request.id, 'declined')}>Decline</button>
+                  <button className="btn-ghost" onClick={() => updateRequest(request.id, 'played')}>Played</button>
+                  <span className="status">{request.status}</span>
+                </div>
+              </article>
+            ))}
+            {!requests.length && <p>No requests yet.</p>}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}
+
+function EventQr({ slug, origin }) {
+  const [src, setSrc] = useState('');
+
+  useEffect(() => {
+    if (!origin) return;
+    const link = `${origin}/event/${slug}`;
+    QRCode.toDataURL(link, { width: 200 }).then(setSrc);
+  }, [slug, origin]);
+
+  const href = origin ? `${origin}/event/${slug}` : ''; 
+
+  return (
+    <div className="row">
+      {src && <img src={src} alt="Event QR code" width="140" height="140" />}
+      <div className="stack">
+        <a href={href} target="_blank" rel="noreferrer">{href}</a>
+        <a href={src} download={`dj-request-${slug}.png`} className="btn-ghost">Download QR</a>
       </div>
     </div>
   );
 }
-
-
-

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,76 +1,42 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
- 
-@layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
- 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
- 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
- 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
- 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
- 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
- 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
- 
-    --radius: 0.5rem;
-  }
- 
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
- 
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
- 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
- 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
- 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
- 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
- 
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
- 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
- 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-  }
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, sans-serif;
+  background: #111827;
+  color: #f9fafb;
 }
- 
-@layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
+a { color: #93c5fd; }
+.container { max-width: 920px; margin: 0 auto; padding: 20px; }
+.mobile { max-width: 520px; }
+.subtitle { color: #cbd5e1; }
+.panel {
+  background: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 12px;
+  padding: 16px;
+  margin: 14px 0;
 }
+.stack { display: flex; flex-direction: column; gap: 10px; }
+.row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.spread { justify-content: space-between; }
+input, textarea, select, button {
+  width: 100%;
+  font-size: 16px;
+  border-radius: 10px;
+  border: 1px solid #4b5563;
+  padding: 10px;
+}
+button { cursor: pointer; }
+.btn-primary { background: #22c55e; color: #052e16; font-weight: 700; border: none; }
+.btn-warn { background: #f97316; color: #fff7ed; border: none; max-width: 120px; }
+.btn-ghost { background: transparent; color: #e5e7eb; border: 1px solid #6b7280; max-width: 180px; }
+.big { font-size: 20px; padding: 16px; }
+.grid { display: grid; gap: 8px; }
+.event-card { text-align: left; background: #111827; color: #f3f4f6; }
+.event-card.selected { border-color: #22c55e; }
+.request { border: 1px solid #374151; border-radius: 10px; padding: 10px; }
+.request.tipped { border-color: #facc15; background: #27210c; }
+.status { margin-left: auto; text-transform: capitalize; color: #cbd5e1; }
+.error { color: #fca5a5; }
+.info { color: #86efac; }
+img { border-radius: 8px; background: #fff; }


### PR DESCRIPTION
### Motivation
- Provide a minimal but production-ready MVP for DJs to manage live song requests with secure DJ accounts, guest-facing request pages (QR-enabled), optional tipping, and fast UI suitable for noisy bar environments.
- Use a simple, portable backend (SQLite + Next.js API routes) and an easy local dev flow so a DJ could run the system locally for an event tonight.

### Description
- Implemented server-side auth and session management with hashed passwords and HTTP-only JWT cookies in `src/lib/auth.js` and auth API routes under `src/pages/api/auth/*`.
- Added persistent SQLite storage and automatic schema creation for `users`, `events`, and `requests` in `src/lib/db.js` and new API routes for events, requests, and payments under `src/pages/api/*` (including request moderation endpoints and event lifecycle endpoints).
- Built guest flow and DJ dashboard UIs: replaced Supabase bits with in-app APIs and added the main dashboard at `src/pages/index.js`, guest request page at `src/pages/event/[id].js`, QR code generation with `qrcode`, and a downloadable QR image for each event.
- Added Square Checkout integration with env-driven real calls and a mock fallback in `src/lib/square.js` and `src/pages/api/payments/create-checkout.js`, a simple in-memory rate limiter in `src/lib/rateLimit.js`, updated CSS for a mobile-first dark UI, and docs/ignore rules in `README.md` and `.gitignore`.

### Testing
- Ran `npm install` to populate dependencies and then `npm run build`, which succeeded after adjusting PostCSS config (build completed and pages/API routes compiled successfully).
- Launched the dev server with `npm run dev` which started at `http://localhost:3000` and a screenshot of the home page was captured to validate the UI.
- Ran `npm run lint` which opened Next.js' interactive ESLint setup in this non-interactive session, so lint was not executed to completion automatically.
- No automated unit tests were added; manual smoke-validation steps above completed successfully (build/dev/start/screenshots).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b4d8eaf508332894490311ced6a82)